### PR TITLE
Update README spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ We’ve “helpfully” included in this repo a `config.json` file to illustrate
 * It listens on each port listed in the config file. Connections to any of those ports routes to one of the correct app’s targets.
 * If an app has multiple targets, you should have a sensible way of balancing between targets.
 * If the target you’ve chosen is unavailable for whatever reason, the connection should still work if there are multiple targets available.
+
 Along with your code, include a NOTES.md that goes over:
 * A short summary of what you built, how it works, and how you landed on this design
 * What might break under a production load? What needs to happen before your proxy is production ready?


### PR DESCRIPTION
Spacing at the start of the Notes criteria is kind of off, though I'm not sure if this is how you'd want it fixed.

Before:
<img width="845" alt="Screen Shot 2022-11-14 at 12 06 54 PM" src="https://user-images.githubusercontent.com/73313780/201755595-3d012b18-0cfe-4540-9d01-8d694c124320.png">

After:
<img width="1022" alt="Screen Shot 2022-11-14 at 12 07 13 PM" src="https://user-images.githubusercontent.com/73313780/201755629-8e5d152c-8a08-47b4-b338-19af01e97dc6.png">

